### PR TITLE
Color node states - not finished but a start

### DIFF
--- a/base_gui/constants.py
+++ b/base_gui/constants.py
@@ -9,8 +9,9 @@ MENU_CHECKBOXES_GENERIC = (
     "MAC 0, ROUTING 1",  # Index 0
     "Hide node labels",  # Index 1
 )
+MENU_CHECKBOX_MAC_AUTOPLAY = 0
 MENU_CHECKBOXES_MAC = (
-    "MAC checkbox here",
+    "Auto-play sim", # index 0
 )
 MENU_CHECKBOXES_ROUTING = (
     "ROUTING checkbox here",
@@ -29,11 +30,11 @@ SIM_SIZE = Vector2(800, 800)
 SCREEN_SIZE = Vector2(SIM_SIZE.x + NAV_WIDTH, SIM_SIZE.y + BOTTOM_HEIGHT)
 
 class SimConsts(object):
-    TIME_MAX_STEPS = 500
+    TIME_MAX_STEPS = 250
     TIME_STEP = 1
 
     # MAC SIMULATION PARAMETERS
-    NUM_NODES_MAC = 7
+    NUM_NODES_MAC = 3
     DISTANCE_SPREAD_SIGMA_MAC = 250
     PACKET_LENGTH_SPACE = 3
     TRANSMISSION_RANGE = 30

--- a/base_gui/constants.py
+++ b/base_gui/constants.py
@@ -1,8 +1,12 @@
 import enum
+from typing import Dict
 
+import pygame
 from pygame import Vector2
 
 # Defines both the number of checkboxes and their labels
+from base_gui.mac.actorstate import MacState
+
 MENU_CHECKBOX_SIMTYPE_INDEX = 0
 MENU_CHECKBOX_NODELABELS_INDEX = 1
 MENU_CHECKBOXES_GENERIC = (
@@ -26,7 +30,7 @@ PIXELS_PER_METER = 10 # Might become dynamic based on zoom later
 SIM_MODE = SimType.MAC  # Not implemented
 NAV_WIDTH = 200
 BOTTOM_HEIGHT = 0
-SIM_SIZE = Vector2(800, 800)
+SIM_SIZE = Vector2(1200, 800)
 SCREEN_SIZE = Vector2(SIM_SIZE.x + NAV_WIDTH, SIM_SIZE.y + BOTTOM_HEIGHT)
 
 class SimConsts(object):
@@ -44,3 +48,13 @@ class SimConsts(object):
     # ROUTING SIMULATION PARAMETERS
     NUM_NODES_ROUTING = 5
     DISTANCE_SPREAD_SIGMA_ROUTING = 30
+
+    STATE_COLOR_DICT : Dict[MacState, pygame.Color] = {
+        MacState.IDLE: pygame.Color("green"),
+        MacState.AWAITING_CTS: pygame.Color("blue"),
+        MacState.AWAITING_DATA: pygame.Color("blue"),
+        MacState.RECEIVING_CTS: pygame.Color("red"),
+        MacState.RECEIVING_DATA: pygame.Color("red"),
+        MacState.SENDING_CTS: pygame.Color("purple"),
+        MacState.SENDING_DATA: pygame.Color("purple")
+    }

--- a/base_gui/gui_components/timeline.py
+++ b/base_gui/gui_components/timeline.py
@@ -3,6 +3,7 @@ from typing import Callable, Any
 from pygame import Vector2
 from pygame.surface import Surface
 
+from base_gui.constants import SimConsts
 from pygame_widgets import Slider
 
 
@@ -26,7 +27,7 @@ class Timeline(object):
             min=2, max=10, step=1, initial=10)
         self.time_slider = Slider(
             self.screen, int(self.position.x), int(self.position.y)+50, int(self.size.x), int(self.size.y),
-            min=0, max=100, step=1, initial=0)
+            min=0, max=SimConsts.TIME_MAX_STEPS, step=SimConsts.TIME_STEP, initial=0)
 
     def render(self):
         self.nodes_slider.draw()

--- a/base_gui/gui_components/timeline.py
+++ b/base_gui/gui_components/timeline.py
@@ -27,7 +27,7 @@ class Timeline(object):
             min=2, max=10, step=1, initial=10)
         self.time_slider = Slider(
             self.screen, int(self.position.x), int(self.position.y)+50, int(self.size.x), int(self.size.y),
-            min=0, max=SimConsts.TIME_MAX_STEPS, step=SimConsts.TIME_STEP, initial=0)
+            min=0, max=SimConsts.TIME_MAX_STEPS-1, step=SimConsts.TIME_STEP, initial=0)
 
     def render(self):
         self.nodes_slider.draw()

--- a/base_gui/main.py
+++ b/base_gui/main.py
@@ -126,8 +126,8 @@ while not game_quit:
             newTimeValue += 1
         if newTimeValue <= 0:
             timeVal = 0
-        elif newTimeValue > SimConsts.TIME_MAX_STEPS:
-            timeVal = SimConsts.TIME_MAX_STEPS
+        elif newTimeValue > SimConsts.TIME_MAX_STEPS-1:
+            timeVal = SimConsts.TIME_MAX_STEPS-1
         else:
             timeVal = newTimeValue
         guiSim.timeline.time_slider.setValue(timeVal)
@@ -152,7 +152,7 @@ while not game_quit:
             print(guiSimMac.show_oracle_states_timeindex)
             guiSimMac.timeline.time_slider.setValue(guiSimMac.show_oracle_states_timeindex)
     else:
-        guiSimMac.draw_oraclestate_waves(timeVal-1)
+        guiSimMac.draw_oraclestate_waves(timeVal)
     guiSim.render_datanodes()
 
     # RENDER - Nodes and menu

--- a/base_gui/main.py
+++ b/base_gui/main.py
@@ -8,7 +8,7 @@ from pygame import Vector2
 from base_gui.app_logging import LOGGER
 from base_gui.constants import SCREEN_SIZE, NAV_WIDTH, SIM_SIZE, SimType, SimConsts, MENU_CHECKBOXES_MAC, \
     MENU_CHECKBOXES_ROUTING, \
-    MENU_CHECKBOX_SIMTYPE_INDEX
+    MENU_CHECKBOX_SIMTYPE_INDEX, MENU_CHECKBOX_MAC_AUTOPLAY
 from base_gui.simulation.gui_sim_mac import GuiSimMac
 from base_gui.simulation.gui_sim_routing import GuiSimRouting
 
@@ -67,9 +67,17 @@ game_quit = False
 guiSim = guiSimMac
 current_sim_type = SimType.MAC
 last_num_nodes = len(guiSim.data_nodes)
-step_difference_millis = 100 # 4 steps per second
+guiSim.timeline.nodes_slider.setValue(last_num_nodes)
+
+# Auto-play sim variables
+step_difference_millis = 200 # 4 steps per second
 simulation_time = pygame.time.get_ticks() # integer index < SimConsts.TIME_MAX_STEPS
+timeline_debounce = 75 # minimum ticks between timeline update by LEFT/RIGHT arrows
+last_timeline_change = pygame.time.get_ticks()
+
 while not game_quit:
+    current_time_sim = pygame.time.get_ticks()
+
     ### CAPTURE
     events = pygame.event.get()
     for event in events:
@@ -102,10 +110,27 @@ while not game_quit:
     # Updating nodes is not smart for now, maybe later.
     # if sliderVal != last_num_nodes:
     #     last_num_nodes = sliderVal
-    timeVal = guiSim.timeline.time_slider.getValue()
 
     ### RENDER
     guiSim.screen.fill((245, 245, 245))
+
+    # Calculate timeline slider value based on keys and waiting
+    timeVal = guiSim.timeline.time_slider.getValue()
+    newTimeValue = timeVal
+    if current_time_sim - last_timeline_change > timeline_debounce:
+        last_timeline_change = current_time_sim
+        keys = pygame.key.get_pressed()
+        if keys[pygame.K_LEFT]:
+            newTimeValue -= 1
+        if keys[pygame.K_RIGHT]:
+            newTimeValue += 1
+        if newTimeValue <= 0:
+            timeVal = 0
+        elif newTimeValue > SimConsts.TIME_MAX_STEPS:
+            timeVal = SimConsts.TIME_MAX_STEPS
+        else:
+            timeVal = newTimeValue
+        guiSim.timeline.time_slider.setValue(timeVal)
 
     # RENDER - Update text by grabbing guiSim children
     font_surface = guiSim.font.render("Number of nodes: {} ".format(sliderVal), True, pygame.Color("black"))
@@ -114,16 +139,20 @@ while not game_quit:
     guiSim.screen.blit(font_surface, dest=(guiSim.timeline.time_slider.x, guiSim.timeline.time_slider.y + 20))
 
     ### PROCESS mouse & RENDER WAVE and NODES
-    current_time_sim = pygame.time.get_ticks()
-    if current_sim_type is SimType.MAC and current_time_sim - simulation_time > step_difference_millis:
-        simulation_time = current_time_sim
-        # mouse_global_pixels = pygame.mouse.get_pos()
-        # if mouse_in_frame(mouse_global_pixels, guiSim.sim_rect):
-        #     mouse_local_pixels = translate_global_to_local(mouse_global_pixels, guiSim.sim_rect, guiSim.local_origin)
-        #     mouse_local_meters = scale_tuple_pix2meter(mouse_local_pixels)
-        # guiSimMac.wave.adjust_origin_local(random_node.position_meters)  # Relative positioning
-        guiSimMac.show_next_oracle_timeindex()
-        print(guiSimMac.show_oracle_states_timeindex)
+    autoplay = guiSim.get_checkbox_value(1, MENU_CHECKBOX_MAC_AUTOPLAY)
+    if autoplay:
+        if current_sim_type is SimType.MAC and current_time_sim - simulation_time > step_difference_millis:
+            simulation_time = current_time_sim
+            # mouse_global_pixels = pygame.mouse.get_pos()
+            # if mouse_in_frame(mouse_global_pixels, guiSim.sim_rect):
+            #     mouse_local_pixels = translate_global_to_local(mouse_global_pixels, guiSim.sim_rect, guiSim.local_origin)
+            #     mouse_local_meters = scale_tuple_pix2meter(mouse_local_pixels)
+            # guiSimMac.wave.adjust_origin_local(random_node.position_meters)  # Relative positioning
+            guiSimMac.show_next_oracle_timeindex()
+            print(guiSimMac.show_oracle_states_timeindex)
+            guiSimMac.timeline.time_slider.setValue(guiSimMac.show_oracle_states_timeindex)
+    else:
+        guiSimMac.draw_oraclestate_waves(timeVal-1)
     guiSim.render_datanodes()
 
     # RENDER - Nodes and menu

--- a/base_gui/simulation/gui_sim_mac.py
+++ b/base_gui/simulation/gui_sim_mac.py
@@ -77,7 +77,6 @@ class GuiSimMac(Game):
             self.show_oracle_states_timeindex += 1
         else:
             self.show_oracle_states_timeindex = 0
-
         self.draw_oraclestate_waves(self.show_oracle_states_timeindex)
 
     def draw_oraclestate_waves(self, time: int):

--- a/base_gui/simulation/gui_sim_mac.py
+++ b/base_gui/simulation/gui_sim_mac.py
@@ -92,6 +92,7 @@ class GuiSimMac(Game):
                     Vector2(message.prop_distance - message.prop_packet_length, message.prop_distance)
                 )
             self.data_nodes[index].set_wavefronts(intransit_message_distances)
+            self.data_nodes[index].set_color_by_state(state.macState)
         pass
 
     def render_datanodes(self):

--- a/base_gui/simulation/node.py
+++ b/base_gui/simulation/node.py
@@ -5,9 +5,9 @@ from pygame import Vector2, Surface, gfxdraw
 from pygame.rect import Rect
 
 from base_gui.constants import SimConsts
+from base_gui.mac.actorstate import MacState
 from base_gui.simulation.wave import Wave
 from base_gui.utils.reference_frame import vector2_global_to_local, scale_tuple_pix2meter
-
 
 class Node(object):
     """
@@ -39,6 +39,9 @@ class Node(object):
             self.reference_frame,
             self.local_origin_offset,
             True)
+
+    def set_color_by_state(self, state: MacState):
+        self.color = SimConsts.STATE_COLOR_DICT[state]
 
     def set_wavefronts(self, wave_specs: List[Vector2]):
         """


### PR DESCRIPTION
The nodes are colored based on state:MacState, but the states are not correctly yet:
- Nodes color RED too often (meaning 'receiving' when there is no packet from a neighbour node arriving on the antenna)
- Nodes color PURPLE too little (meaning 'carrier-sense-cleared transmitting', but they are sending much more than that)
- Nodes color GREEN too little (doesnt seem to reset)

Bugfixes and improvements
- Implemented timeslider and auto-play checkbox.
- Increased window size
- Corrected node-count slider (still not attached)